### PR TITLE
fix: handle corrupted config files gracefully instead of crashing

### DIFF
--- a/common/src/main/java/me/thosea/badoptimizations/config/Config.java
+++ b/common/src/main/java/me/thosea/badoptimizations/config/Config.java
@@ -82,7 +82,7 @@ public final class Config {
 		// config v5 adds caching hooks and changes debug hud comment
 		// config v6 only changes comments
 
-		if(!ctx.fromExistingFile() || ver < CURRENT_CONFIG_VER) {
+		if(!ctx.fromExistingFile() || ver < CURRENT_CONFIG_VER || ctx.hasMissingOptions) {
 			try {
 				writeConfig();
 			} catch(Exception e) {
@@ -126,6 +126,6 @@ public final class Config {
 				CURRENT_CONFIG_VER
 		);
 
-		Files.writeString(FILE, data, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+		Files.writeString(FILE, data, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
 	}
 }

--- a/common/src/main/java/me/thosea/badoptimizations/config/ConfigLoadContext.java
+++ b/common/src/main/java/me/thosea/badoptimizations/config/ConfigLoadContext.java
@@ -13,6 +13,7 @@ public final class ConfigLoadContext {
 	public final ModIncompatibilities incompats = new ModIncompatibilities();
 	public final int version;
 	@Nullable public final Properties properties;
+	public boolean hasMissingOptions = false;
 
 	public ConfigLoadContext() {
 		if(Files.exists(FILE)) {
@@ -32,10 +33,7 @@ public final class ConfigLoadContext {
 				return prop;
 			}
 		} catch(Exception e) {
-			// TODO: does passing Exception as object still log the stack trace?
-			LOGGER.error("Failed to load config from " + FILE + ". " +
-					"If you need to, you can delete the file to generate a new one.", e);
-			System.exit(1);
+			LOGGER.error("Failed to load config from " + FILE + ". Config will be regenerated with default values.", e);
 			return null;
 		}
 	}
@@ -74,7 +72,8 @@ public final class ConfigLoadContext {
 
 		String str = properties.getProperty(name);
 		if(str == null) {
-			throw new IllegalStateException("Config option " + name + " not found");
+			LOGGER.warn("Config option {} not found - using default value. Config will be regenerated.", name);
+			hasMissingOptions = true;
 		}
 		return str;
 	}


### PR DESCRIPTION
- Use default values when config options are missing instead of throwing
- Regenerate config automatically when options are missing or malformed
- Add TRUNCATE_EXISTING to prevent leftover data from corrupting config
- Remove System.exit(1) on config parse errors to allow recovery

Fixes #115